### PR TITLE
Studying error handling 404

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -21,7 +21,7 @@ class UserController extends Controller
     {
         $title = 'User details';
 
-        $user = User::find($id);
+        $user = User::findOrFail($id);
 
         return view('show', compact('user', 'title'));
     }

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>404</title>
+</head>
+<body>
+    <h1>Page not found</h1>
+</body>
+</html>

--- a/tests/Feature/UsersModuleTest.php
+++ b/tests/Feature/UsersModuleTest.php
@@ -60,6 +60,14 @@ class UsersModuleTest extends TestCase
     }
 
     /** @test */
+    function it_displays_a_404_error_if_the_user_is_not_found()
+    {
+        $this->get('/users/1000')
+            ->assertStatus(404)
+            ->assertSee('Page not found');
+    }
+
+    /** @test */
     function it_loads_the_create_users_page()
     {
         $this->get('/users/create')


### PR DESCRIPTION
# WHAT
・存在しないビューまたは、エラーの際にerrorsの中の404のついたビューファイルを使って404 not foundエラーを返す
# WHY
・存在しないパスを指定の際に画面にエラービューを表示するため